### PR TITLE
vendor: Dexpreopt SystemUIGoogle

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -209,9 +209,11 @@ PRODUCT_PACKAGES += \
 endif
 endif
 
-# SystemUI
+# Dex preopt
 PRODUCT_DEXPREOPT_SPEED_APPS += \
-    SystemUI
+    SystemUIGoogle \
+    NexusLauncherRelease \
+    GoogleDialer
 
 PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
     dalvik.vm.systemuicompilerfilter=speed


### PR DESCRIPTION
PixelOS doesn't have SystemUI it's SystemUIGoogle instead.

While at it:
* Change comment for appropriate naming ("SystemUI" to "Dex preopt")
* Include PixelLauncher (same as PE) & GoogleDialer (improves initial launch speeds noticeably + it's essential app)