### PR TITLE
config: don't build AudioFX,bash,htop,nano,vim

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -139,13 +139,9 @@ PRODUCT_PACKAGES += \
 
 # Extra tools
 PRODUCT_PACKAGES += \
-    bash \
     curl \
     getcap \
-    htop \
-    nano \
-    setcap \
-    vim
+    setcap
 
 PRODUCT_ARTIFACT_PATH_REQUIREMENT_ALLOWED_LIST += \
     system/bin/curl \

--- a/config/common_full.mk
+++ b/config/common_full.mk
@@ -8,11 +8,6 @@ PRODUCT_PACKAGES += \
     Aperture
 endif
 
-ifneq ($(TARGET_EXCLUDES_AUDIOFX),true)
-PRODUCT_PACKAGES += \
-    AudioFX
-endif
-
 # Extra cmdline tools
 PRODUCT_PACKAGES += \
     unrar \


### PR DESCRIPTION
These aren't forked here.