### PR TITLE
config: Disable default frame rate limit for games

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -185,6 +185,10 @@ PRODUCT_PACKAGES += \
     ssh-keygen \
     start-ssh
 
+# Disable default frame rate limit for games
+PRODUCT_PRODUCT_PROPERTIES += \
+    debug.graphics.game_default_frame_rate.disabled=true
+
 PRODUCT_COPY_FILES += \
     vendor/aosp/prebuilt/common/etc/init/init.openssh.rc:$(TARGET_COPY_OUT_PRODUCT)/etc/init/init.openssh.rc
 


### PR DESCRIPTION
Android 15 limits refresh rate to 60hz for games unless we enable the developer option 'Disable default frame rate for games' manually. Adding this prop enables it by default.